### PR TITLE
Add template for ingress to XNAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ helm template xnat-core ./xnat-0.0.1.tgz > build/chart.yaml
 
 | Name                                             | Description                              | Value                      |
 | ------------------------------------------------ | ---------------------------------------- | -------------------------- |
+| `web.siteUrl`                                    | Site URL                                 | `""`                       |
 | `web.auth.openid.clientId`                       | OpenID client ID                         | `""`                       |
 | `web.auth.openid.clientSecret`                   | OpenID client secret                     | `""`                       |
 | `web.auth.openid.accessTokenUri`                 | OpenID access token URI                  | `""`                       |

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -11,6 +11,16 @@ metadata:
   {{- end }}
 spec:
   ingressClassName: {{ .Values.web.ingress.className }}
+  {{- if .Values.web.ingress.tls }}
+  tls:
+    {{- range .Values.web.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
     {{- range .Values.web.ingress.hosts }}
     - host: {{ .host | quote }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,18 +1,18 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.web.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "xnat.fullname" . }}-web
   labels:
     {{- include "xnat.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.web.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ .Values.ingress.className }}
+  ingressClassName: {{ .Values.web.ingress.className }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.web.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "xnat.fullname" . }}-web
+  labels:
+    {{- include "xnat.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "xnat.fullname" $ }}-headless
+                port: 
+                  number: {{ $.Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -179,6 +179,9 @@ postgresql:
 
 ## @section XNAT Web parameters
 web:
+  ## @param web.siteUrl Site URL
+  siteUrl: ""
+
   ## @param web.auth.openid.clientId OpenID client ID
   ## @param web.auth.openid.clientSecret OpenID client secret
   ## @param web.auth.openid.accessTokenUri OpenID access token URI


### PR DESCRIPTION
- add `ingress.yaml` to create an ingress to XNAT if `web.ingress.enabled` is `true`
- add description of `web.siteUrl` value used [here](https://github.com/UCL-MIRSG/xnat-chart/blob/854f69af26cc57fc87f5842bbe3f914c48e029fc/chart/templates/secrets.yaml#L40)