### PR TITLE
Give permission to write contents to publish.yaml workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 env:


### PR DESCRIPTION
We're running into [this error](https://github.com/helm/chart-releaser-action/issues/110) as the workflow does not have permission to write to the repo