### PR TITLE
Use CloudNativePG to deploy Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ helm install \
 --set postgresql.cluster.initdb.password=xnat \
 --set postgresql.cluster.initdb.createSecret=true \
 --namespace xnat-core \
---create-namespace \
 xnat-core xnat-0.0.8.tgz
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ helm install \
 --set postgresql.cluster.initdb.createSecret=true \
 --namespace xnat-core \
 --create-namespace \
-xnat-core xnat-0.0.7.tgz
+xnat-core xnat-0.0.8.tgz
 ```
 
 Note that omitting the `namespace` option and `create-namespace` flag will
@@ -76,7 +76,7 @@ helm uninstall xnat-core -n xnat-core
 The chart can be rendered using the default values with the following command:
 
 ```shell
-helm template xnat-core ./xnat-0.0.7.tgz > build/chart.yaml
+helm template xnat-core ./xnat-0.0.8.tgz > build/chart.yaml
 ```
 
 ## Parameters

--- a/README.md
+++ b/README.md
@@ -13,7 +13,20 @@ method. For example, using [kind](https://kind.sigs.k8s.io/):
 kind create cluster --name xnat
 ```
 
-### Package the chart
+### Install the CNPG Operator
+
+We use the [CNPG Operator](https://github.com/cloudnative-pg/cloudnative-pg) to
+deploy Postgres. The operator can be installed using Helm:
+
+```bash
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm upgrade --install cnpg \
+  --namespace cnpg-system \
+  --create-namespace \
+  cnpg/cloudnative-pg
+```
+
+### Package and install `xnat-chart`
 
 To install a local copy of the chart, first create a package:
 
@@ -21,9 +34,7 @@ To install a local copy of the chart, first create a package:
 helm package --dependency-update chart
 ```
 
-### Install the chart
-
-Install the packaged chart in the cluster with the following command:
+Then install the packaged chart in the cluster with the following command:
 
 ```shell
 helm install \

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ Install the packaged chart in the cluster with the following command:
 
 ```shell
 helm install \
---set image.name=xnat-core
+--set image.name=xnat-core \
 --set image.tag=0.0.1 \
 --set imageCredentials.enabled=true \
 --set imageCredentials.registry=ghcr.io \
 --set imageCredentials.username=<GH_USERNAME> \
 --set imageCredentials.password=<GH_PAT> \
---set postgresql.auth.password=xnat \
+--set postgresql.cluster.initdb.password=xnat \
+--set postgresql.cluster.initdb.createSecret=true \
 --namespace xnat-core \
 --create-namespace \
 xnat-core xnat-0.0.7.tgz
@@ -105,7 +106,6 @@ helm template xnat-core ./xnat-0.0.7.tgz > build/chart.yaml
 | `volumes[1].size`              | XNAT archive Volume size                                | `8Gi`                                                |
 | `volumes[1].storageClass`      | XNAT archive Volume storageClass                        | `nil`                                                |
 | `volumes[2].name`              | XNAT instance configuration Volume name                 | `xnat-config`                                        |
-| `volumes[2].secret.secretName` | XNAT instance configuration Volume secret name          | `xnat-conf`                                          |
 | `volumes[3].name`              | XNAT OpenID configuration Volume name                   | `xnat-openid-config`                                 |
 | `volumes[3].secret.secretName` | XNAT OpenID configuration Volume secret name            | `openid-conf`                                        |
 | `volumes[4].name`              | XNAT prearchive Volume name                             | `xnat-prearchive`                                    |
@@ -123,7 +123,6 @@ helm template xnat-core ./xnat-0.0.7.tgz > build/chart.yaml
 | `volumeMounts[1].subPath`      | XNAT archive Volume sub path                            | `nil`                                                |
 | `volumeMounts[2].name`         | XNAT instance configuration Volume name                 | `xnat-config`                                        |
 | `volumeMounts[2].mountPath`    | XNAT instance configuration Volume mount path           | `/data/xnat/home/config/xnat-conf.properties`        |
-| `volumeMounts[2].readOnly`     | XNAT instance configuration Volume read only            | `true`                                               |
 | `volumeMounts[2].subPath`      | XNAT instance configuration Volume sub path             | `xnat-conf.properties`                               |
 | `volumeMounts[3].name`         | XNAT OpenID configuration Volume name                   | `xnat-openid-config`                                 |
 | `volumeMounts[3].mountPath`    | XNAT OpenID configuration Volume mount path             | `/data/xnat/home/config/auth/openid-conf.properties` |
@@ -133,65 +132,66 @@ helm template xnat-core ./xnat-0.0.7.tgz > build/chart.yaml
 | `volumeMounts[4].mountPath`    | XNAT prearchive Volume mount path                       | `/data/xnat/prearchive`                              |
 | `volumeMounts[4].subPath`      | XNAT prearchive Volume sub path                         | `nil`                                                |
 
-### XNAT Database parameters
-
-| Name                                           | Description                                      | Value                  |
-| ---------------------------------------------- | ------------------------------------------------ | ---------------------- |
-| `postgresql.enabled`                           | Enable or disable the PostgreSQL deployment      | `true`                 |
-| `postgresql.auth.database`                     | PostgreSQL database name                         | `xnat`                 |
-| `postgresql.auth.username`                     | PostgreSQL username                              | `xnat`                 |
-| `postgresql.auth.password`                     | PostgreSQL password. Make sure to override this. | `xnat`                 |
-| `postgresql.auth.postgresPassword`             | PostgreSQL password. Make sure to override this. | `postgres`             |
-| `postgresql.image.tag`                         | PostgreSQL image tag                             | `14.17.0-debian-12-r2` |
-| `postgresql.primary.resources.requests.cpu`    | CPU request                                      | `1`                    |
-| `postgresql.primary.resources.requests.memory` | Memory request                                   | `4000Mi`               |
-| `postgresql.primary.resources.limits.cpu`      | CPU limit                                        | `2`                    |
-| `postgresql.primary.resources.limits.memory`   | Memory limit                                     | `4000Mi`               |
-
 ### XNAT Web parameters
 
-| Name                                             | Description                              | Value                      |
-| ------------------------------------------------ | ---------------------------------------- | -------------------------- |
-| `web.siteUrl`                                    | Site URL                                 | `""`                       |
-| `web.auth.openid.clientId`                       | OpenID client ID                         | `""`                       |
-| `web.auth.openid.clientSecret`                   | OpenID client secret                     | `""`                       |
-| `web.auth.openid.accessTokenUri`                 | OpenID access token URI                  | `""`                       |
-| `web.auth.openid.userAuthUri`                    | OpenID user authentication URI           | `""`                       |
-| `web.auth.openid.link`                           | OpenID link                              | `""`                       |
-| `web.podAnnotations`                             | Annotations to add to the web pod        | `{}`                       |
-| `web.podLabels`                                  | Labels to add to the web pod             | `{}`                       |
-| `web.podSecurityContext.runAsUser`               | Pod security context runAsUser           | `1000`                     |
-| `web.securityContext`                            | Pod security context                     | `{}`                       |
-| `web.ingress.enabled`                            | Enable or disable the ingress deployment | `false`                    |
-| `web.ingress.className`                          | Ingress class name                       | `""`                       |
-| `web.ingress.annotations`                        | Ingress annotations                      | `{}`                       |
-| `web.ingress.hosts[0].host`                      | Ingress host                             | `chart-example.local`      |
-| `web.ingress.hosts[0].paths[0].path`             | Ingress path                             | `/`                        |
-| `web.ingress.hosts[0].paths[0].pathType`         | Ingress path type                        | `ImplementationSpecific`   |
-| `web.ingress.tls`                                | Ingress TLS                              | `[]`                       |
-| `web.resources.limits.cpu`                       | CPU and memory limits                    | `2`                        |
-| `web.resources.limits.memory`                    | Memory limits                            | `4000Mi`                   |
-| `web.resources.requests.cpu`                     | CPU and memory requests                  | `1`                        |
-| `web.resources.requests.memory`                  | Memory requests                          | `4000Mi`                   |
-| `web.livenessProbe.failureThreshold`             | Liveness probe failure threshold         | `1`                        |
-| `web.livenessProbe.httpGet.path`                 | Liveness probe httpGet path              | `/app/template/Login.vm#!` |
-| `web.livenessProbe.httpGet.port`                 | Liveness probe httpGet port              | `http`                     |
-| `web.livenessProbe.periodSeconds`                | Liveness probe period seconds            | `10`                       |
-| `web.livenessProbe.timeoutSeconds`               | Liveness probe timeout seconds           | `5`                        |
-| `web.readinessProbe.failureThreshold`            | Readiness probe failure threshold        | `1`                        |
-| `web.readinessProbe.httpGet.path`                | Readiness probe httpGet path             | `/app/template/Login.vm#!` |
-| `web.readinessProbe.httpGet.port`                | Readiness probe httpGet port             | `http`                     |
-| `web.readinessProbe.periodSeconds`               | Readiness probe period seconds           | `10`                       |
-| `web.readinessProbe.timeoutSeconds`              | Readiness probe timeout seconds          | `3`                        |
-| `web.startupProbe.failureThreshold`              | Startup probe failure threshold          | `15`                       |
-| `web.startupProbe.httpGet.path`                  | Startup probe httpGet path               | `/app/template/Login.vm#!` |
-| `web.startupProbe.httpGet.port`                  | Startup probe httpGet port               | `http`                     |
-| `web.startupProbe.periodSeconds`                 | Startup probe period seconds             | `10`                       |
-| `web.startupProbe.initialDelaySeconds`           | Startup probe initial delay seconds      | `20`                       |
-| `web.autoscaling.enabled`                        | Enable or disable the autoscaling        | `false`                    |
-| `web.autoscaling.minReplicas`                    | Minimum number of replicas               | `1`                        |
-| `web.autoscaling.maxReplicas`                    | Maximum number of replicas               | `100`                      |
-| `web.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilisation percentage        | `80`                       |
-| `web.nodeSelector`                               | Node selector                            | `{}`                       |
-| `web.tolerations`                                | Tolerations to add to the web pod        | `[]`                       |
-| `web.affinity`                                   | Affinity to add to the web pod           | `{}`                       |
+| Name                                                      | Description                                                        | Value                                                       |
+| --------------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------- |
+| `web.siteUrl`                                             | Site URL                                                           | `""`                                                        |
+| `web.auth.openid.clientId`                                | OpenID client ID                                                   | `""`                                                        |
+| `web.auth.openid.clientSecret`                            | OpenID client secret                                               | `""`                                                        |
+| `web.auth.openid.accessTokenUri`                          | OpenID access token URI                                            | `""`                                                        |
+| `web.auth.openid.userAuthUri`                             | OpenID user authentication URI                                     | `""`                                                        |
+| `web.auth.openid.link`                                    | OpenID link                                                        | `""`                                                        |
+| `web.podAnnotations`                                      | Annotations to add to the web pod                                  | `{}`                                                        |
+| `web.podLabels`                                           | Labels to add to the web pod                                       | `{}`                                                        |
+| `web.podSecurityContext.runAsUser`                        | Pod security context runAsUser                                     | `1000`                                                      |
+| `web.securityContext`                                     | Pod security context                                               | `{}`                                                        |
+| `web.ingress.enabled`                                     | Enable or disable the ingress deployment                           | `false`                                                     |
+| `web.ingress.className`                                   | Ingress class name                                                 | `""`                                                        |
+| `web.ingress.annotations`                                 | Ingress annotations                                                | `{}`                                                        |
+| `web.ingress.hosts[0].host`                               | Ingress host                                                       | `chart-example.local`                                       |
+| `web.ingress.hosts[0].paths[0].path`                      | Ingress path                                                       | `/`                                                         |
+| `web.ingress.hosts[0].paths[0].pathType`                  | Ingress path type                                                  | `ImplementationSpecific`                                    |
+| `web.ingress.tls`                                         | Ingress TLS                                                        | `[]`                                                        |
+| `web.resources.limits.cpu`                                | CPU and memory limits                                              | `2`                                                         |
+| `web.resources.limits.memory`                             | Memory limits                                                      | `4000Mi`                                                    |
+| `web.resources.requests.cpu`                              | CPU and memory requests                                            | `1`                                                         |
+| `web.resources.requests.memory`                           | Memory requests                                                    | `4000Mi`                                                    |
+| `web.livenessProbe.failureThreshold`                      | Liveness probe failure threshold                                   | `1`                                                         |
+| `web.livenessProbe.httpGet.path`                          | Liveness probe httpGet path                                        | `/app/template/Login.vm#!`                                  |
+| `web.livenessProbe.httpGet.port`                          | Liveness probe httpGet port                                        | `http`                                                      |
+| `web.livenessProbe.periodSeconds`                         | Liveness probe period seconds                                      | `10`                                                        |
+| `web.livenessProbe.timeoutSeconds`                        | Liveness probe timeout seconds                                     | `5`                                                         |
+| `web.readinessProbe.failureThreshold`                     | Readiness probe failure threshold                                  | `1`                                                         |
+| `web.readinessProbe.httpGet.path`                         | Readiness probe httpGet path                                       | `/app/template/Login.vm#!`                                  |
+| `web.readinessProbe.httpGet.port`                         | Readiness probe httpGet port                                       | `http`                                                      |
+| `web.readinessProbe.periodSeconds`                        | Readiness probe period seconds                                     | `10`                                                        |
+| `web.readinessProbe.timeoutSeconds`                       | Readiness probe timeout seconds                                    | `3`                                                         |
+| `web.startupProbe.failureThreshold`                       | Startup probe failure threshold                                    | `15`                                                        |
+| `web.startupProbe.httpGet.path`                           | Startup probe httpGet path                                         | `/app/template/Login.vm#!`                                  |
+| `web.startupProbe.httpGet.port`                           | Startup probe httpGet port                                         | `http`                                                      |
+| `web.startupProbe.periodSeconds`                          | Startup probe period seconds                                       | `10`                                                        |
+| `web.startupProbe.initialDelaySeconds`                    | Startup probe initial delay seconds                                | `20`                                                        |
+| `web.autoscaling.enabled`                                 | Enable or disable the autoscaling                                  | `false`                                                     |
+| `web.autoscaling.minReplicas`                             | Minimum number of replicas                                         | `1`                                                         |
+| `web.autoscaling.maxReplicas`                             | Maximum number of replicas                                         | `100`                                                       |
+| `web.autoscaling.targetCPUUtilizationPercentage`          | Target CPU utilisation percentage                                  | `80`                                                        |
+| `web.nodeSelector`                                        | Node selector                                                      | `{}`                                                        |
+| `web.tolerations`                                         | Tolerations to add to the web pod                                  | `[]`                                                        |
+| `web.affinity`                                            | Affinity to add to the web pod                                     | `{}`                                                        |
+| `postgresql.enabled`                                      | Whether to deploy a PostgreSQL cluster                             | `true`                                                      |
+| `postgresql.backups.enabled`                              | Whether to enable database backups                                 | `false`                                                     |
+| `postgresql.cluster.imageName`                            | Name of the PostgreSQL container image                             | `ghcr.io/cloudnative-pg/postgresql:14.17-standard-bookworm` |
+| `postgresql.cluster.instances`                            | Number of PostgreSQL instances                                     | `3`                                                         |
+| `postgresql.cluster.postgresql.parameters.shared_buffers` | Amount of memory used for shared buffers                           | `512MB`                                                     |
+| `postgresql.cluster.resources.requests.cpu`               | CPU request                                                        | `1`                                                         |
+| `postgresql.cluster.resources.requests.memory`            | Memory request                                                     | `2Gi`                                                       |
+| `postgresql.cluster.resources.limits.cpu`                 | CPU limit                                                          | `2`                                                         |
+| `postgresql.cluster.resources.limits.memory`              | Memory limit                                                       | `4Gi`                                                       |
+| `postgresql.cluster.storage.size`                         | Size of the storage                                                | `8Gi`                                                       |
+| `postgresql.cluster.initdb.database`                      | PostgreSQL database name                                           | `xnat`                                                      |
+| `postgresql.cluster.initdb.owner`                         | PostgreSQL owner                                                   | `xnat`                                                      |
+| `postgresql.cluster.initdb.secret.name`                   | Name of the secret containing credentials for the database         | `pg-user-secret`                                            |
+| `postgresql.cluster.initdb.createSecret`                  | Whether to create a secret containing credentials for the database | `false`                                                     |
+| `postgresql.cluster.initdb.password`                      | PostgreSQL password                                                | `""`                                                        |
+| `postgresql.cluster.version.postgresql`                   | PostgreSQL major version to use                                    | `14`                                                        |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ helm upgrade --install cnpg \
   cnpg/cloudnative-pg
 ```
 
+### Create a namespace to install the chart
+
+Create a manifest for the namespace:
+
+```bash
+cat <<EOF > namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: xnat-core
+EOF
+```
+
+Create the namespace:
+
+```bash
+kubectl apply -f namespace.yaml
+```
+
 ### Create a secret containing Postgres credentials
 
 Create a manifest for the secret:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ stringData:
 kind: Secret
 metadata:
   name: pg-user-secret
+  namespace: xnat-core
 type: kubernetes.io/basic-auth
 EOF
 ```

--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: postgresql
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.4.14
-digest: sha256:0e5da4dedbf721c1a7bc36c68794eadacdab1434919cd0b7bbb42ace49126bb6
-generated: "2025-03-03T16:29:23.32698Z"
+- name: cluster
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.2.1
+digest: sha256:cdced694cd77b6ffe6c99e0b71c62f825c80568015db6be4f25993eeb5bc3b95
+generated: "2025-03-06T14:13:21.317793Z"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: xnat
 description: A Helm chart for deploying XNAT on Kubernetes
 type: application
-version: 0.0.7
+version: 0.0.8
 # XNAT version deployed in the chart
 appVersion: 1.8.10
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -8,7 +8,8 @@ version: 0.0.7
 appVersion: 1.8.10
 
 dependencies:
-  - name: postgresql
-    version: 16.4.14
-    repository: oci://registry-1.docker.io/bitnamicharts
+  - name: cluster
+    alias: postgresql
+    version: 0.2.1
+    repository: https://cloudnative-pg.github.io/charts
     condition: postgresql.enabled

--- a/chart/templates/_postgresql.tpl
+++ b/chart/templates/_postgresql.tpl
@@ -1,13 +1,6 @@
 {{/*
-Name of postgresql deployment
-*/}}
-{{- define "xnat.postgresql.fullname" -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
 Name of the postgresql clusterIP service
 */}}
 {{- define "xnat.postgresql.svc" -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-rw" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -31,14 +31,3 @@ type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
 {{ end }}
----
-{{- if .Values.postgresql.cluster.initdb.createSecret }}
-apiVersion: v1
-stringData:
-  username: {{ .Values.postgresql.cluster.initdb.owner }}
-  password: {{ .Values.postgresql.cluster.initdb.password }}
-kind: Secret
-metadata:
-  name: {{ .Values.postgresql.cluster.initdb.secret.name }}
-type: kubernetes.io/basic-auth
-{{ end }}

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -1,32 +1,6 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: xnat-conf
-  labels: {{- include "xnat.labels" . | nindent 4 }}
-type: Opaque
-stringData:
-  xnat-conf.properties: |
-    #
-    # xnat-conf.properties
-    # XNAT http://www.xnat.org
-    # Copyright (c) 2016, Washington University School of Medicine
-    # All Rights Reserved
-    #
-    # Released under the Simplified BSD.
-    #
-    datasource.driver=org.postgresql.Driver
-    datasource.url=jdbc:postgresql://{{ template "xnat.postgresql.svc" . }}/{{ .Values.postgresql.auth.database }}
-    datasource.username={{ .Values.postgresql.auth.username }}
-    datasource.password={{ .Values.postgresql.auth.password }}
-    hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
-    hibernate.hbm2ddl.auto=update
-    hibernate.show_sql=false
-    hibernate.cache.use_second_level_cache=true
-    hibernate.cache.use_query_cache=true
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: openid-conf
   labels: {{- include "xnat.labels" . | nindent 4 }}
 type: Opaque
@@ -56,4 +30,15 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{ end }}
+---
+{{- if .Values.postgresql.cluster.initdb.createSecret }}
+apiVersion: v1
+stringData:
+  username: {{ .Values.postgresql.cluster.initdb.owner }}
+  password: {{ .Values.postgresql.cluster.initdb.password }}
+kind: Secret
+metadata:
+  name: {{ .Values.postgresql.cluster.initdb.secret.name }}
+type: kubernetes.io/basic-auth
 {{ end }}

--- a/chart/templates/xnat-web-statefulset.yaml
+++ b/chart/templates/xnat-web-statefulset.yaml
@@ -65,25 +65,59 @@ spec:
           image: {{ include "xnat.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: PGPASSWORD
-              {{- if .Values.postgresql.auth.existingSecret }}
+            - name: PGUSER
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.postgresql.auth.existingSecret }}
-                  key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
-              {{- else }}
-              value: {{ .Values.postgresql.auth.password | quote }}
-              {{- end }}
+                  name: {{ .Values.postgresql.cluster.initdb.secret.name }}
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.cluster.initdb.secret.name }}
+                  key: password
           command:
             - 'bash'
             - '-c'
             - |
               set -e
-              until psql -U {{ .Values.postgresql.auth.username }} -h {{ template "xnat.postgresql.svc" . }} -c '\q'; do
+              until psql -h {{ template "xnat.postgresql.svc" . }} -c '\q'; do
                 >&2 echo "Postgres is unavailable - sleeping"
                 sleep 30
               done
               >&2 echo "Postgres is up"
+        - name: xnat-datasource
+          image: {{ include "xnat.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: XNAT_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.cluster.initdb.secret.name }}
+                  key: username
+            - name: XNAT_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.cluster.initdb.secret.name }}
+                  key: password
+          command:
+            - 'bash'
+            - '-c'
+            - |
+              set -x
+              cat <<EOF > /xnat/xnat-conf.properties
+              datasource.driver=org.postgresql.Driver
+              datasource.url=jdbc:postgresql://{{ template "xnat.postgresql.svc" . }}/{{ .Values.postgresql.cluster.initdb.database }}
+              datasource.username=$XNAT_DATASOURCE_USERNAME
+              datasource.password=$XNAT_DATASOURCE_PASSWORD
+              hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
+              hibernate.hbm2ddl.auto=update
+              hibernate.show_sql=false
+              hibernate.cache.use_second_level_cache=true
+              hibernate.cache.use_query_cache=true
+              EOF
+          volumeMounts:
+            - name: xnat-config
+              mountPath: /xnat
         - name: node-conf
           image: {{ include "xnat.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -324,8 +324,6 @@ web:
 ## @param postgresql.cluster.initdb.database PostgreSQL database name
 ## @param postgresql.cluster.initdb.owner PostgreSQL owner
 ## @param postgresql.cluster.initdb.secret.name Name of the secret containing credentials for the database
-## @param postgresql.cluster.initdb.createSecret Whether to create a secret containing credentials for the database
-## @param postgresql.cluster.initdb.password PostgreSQL password
 ## @param postgresql.cluster.version.postgresql PostgreSQL major version to use
 postgresql:
   enabled: true
@@ -351,7 +349,5 @@ postgresql:
       owner: xnat
       secret:
         name: pg-user-secret
-      createSecret: false
-      password: ""
     version:
       postgresql: "14"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -80,7 +80,6 @@ persistence:
 ## @param volumes[1].size XNAT archive Volume size
 ## @param volumes[1].storageClass XNAT archive Volume storageClass
 ## @param volumes[2].name XNAT instance configuration Volume name
-## @param volumes[2].secret.secretName XNAT instance configuration Volume secret name
 ## @param volumes[3].name XNAT OpenID configuration Volume name
 ## @param volumes[3].secret.secretName XNAT OpenID configuration Volume secret name
 ## @param volumes[4].name XNAT prearchive Volume name
@@ -101,8 +100,6 @@ volumes:
     size: 8Gi
     storageClass:
   - name: xnat-config
-    secret:
-      secretName: xnat-conf
   - name: xnat-openid-config
     secret:
       secretName: openid-conf
@@ -123,7 +120,6 @@ volumes:
 ## @param volumeMounts[1].subPath XNAT archive Volume sub path
 ## @param volumeMounts[2].name XNAT instance configuration Volume name
 ## @param volumeMounts[2].mountPath XNAT instance configuration Volume mount path
-## @param volumeMounts[2].readOnly XNAT instance configuration Volume read only
 ## @param volumeMounts[2].subPath XNAT instance configuration Volume sub path
 ## @param volumeMounts[3].name XNAT OpenID configuration Volume name
 ## @param volumeMounts[3].mountPath XNAT OpenID configuration Volume mount path
@@ -141,7 +137,6 @@ volumeMounts:
     subPath:
   - name: xnat-config
     mountPath: /data/xnat/home/config/xnat-conf.properties
-    readOnly: true
     subPath: xnat-conf.properties
   - name: xnat-openid-config
     mountPath: /data/xnat/home/config/auth/openid-conf.properties
@@ -150,35 +145,6 @@ volumeMounts:
   - name: xnat-prearchive
     mountPath: /data/xnat/prearchive
     subPath:
-
-## @section XNAT Database parameters
-## @param postgresql.enabled Enable or disable the PostgreSQL deployment
-## @param postgresql.auth.database PostgreSQL database name
-## @param postgresql.auth.username PostgreSQL username
-## @param postgresql.auth.password PostgreSQL password. Make sure to override this.
-## @param postgresql.auth.postgresPassword PostgreSQL password. Make sure to override this.
-## @param postgresql.image.tag PostgreSQL image tag
-## @param postgresql.primary.resources.requests.cpu CPU request
-## @param postgresql.primary.resources.requests.memory Memory request
-## @param postgresql.primary.resources.limits.cpu CPU limit
-## @param postgresql.primary.resources.limits.memory Memory limit
-postgresql:
-  enabled: true
-  auth:
-    database: xnat
-    username: xnat
-    password: xnat
-    postgresPassword: postgres
-  image:
-    tag: 14.17.0-debian-12-r2
-  primary:
-    resources:
-      requests:
-        cpu: 1
-        memory: 4000Mi
-      limits:
-        cpu: 2
-        memory: 4000Mi
 
 ## @section XNAT Web parameters
 web:
@@ -313,3 +279,79 @@ web:
 
   ## @param web.affinity Affinity to add to the web pod
   affinity: {}
+
+### @section XNAT Database parameters
+### @param postgresql.enabled Enable or disable the PostgreSQL deployment
+### @param postgresql.auth.database PostgreSQL database name
+### @param postgresql.auth.username PostgreSQL username
+### @param postgresql.auth.password PostgreSQL password. Make sure to override this.
+### @param postgresql.auth.postgresPassword PostgreSQL password. Make sure to override this.
+### @param postgresql.image.tag PostgreSQL image tag
+### @param postgresql.primary.resources.requests.cpu CPU request
+### @param postgresql.primary.resources.requests.memory Memory request
+### @param postgresql.primary.resources.limits.cpu CPU limit
+### @param postgresql.primary.resources.limits.memory Memory limit
+#postgresql:
+#  enabled: true
+#  auth:
+#    database: xnat
+#    username: xnat
+#    password: xnat
+#    postgresPassword: postgres
+#  image:
+#    tag: 14.17.0-debian-12-r2
+#  primary:
+#    resources:
+#      requests:
+#        cpu: 1
+#        memory: 4000Mi
+#      limits:
+#        cpu: 2
+#        memory: 4000Mi
+#
+
+### @section XNAT Database parameters
+## @param postgresql.enabled Whether to deploy a PostgreSQL cluster
+## @param postgresql.backups.enabled Whether to enable database backups
+## @param postgresql.cluster.imageName Name of the PostgreSQL container image
+## @param postgresql.cluster.instances Number of PostgreSQL instances
+## @param postgresql.cluster.postgresql.parameters.shared_buffers Amount of memory used for shared buffers
+## @param postgresql.cluster.resources.requests.cpu CPU request
+## @param postgresql.cluster.resources.requests.memory Memory request
+## @param postgresql.cluster.resources.limits.cpu CPU limit
+## @param postgresql.cluster.resources.limits.memory Memory limit
+## @param postgresql.cluster.storage.size Size of the storage
+## @param postgresql.cluster.initdb.database PostgreSQL database name
+## @param postgresql.cluster.initdb.owner PostgreSQL owner
+## @param postgresql.cluster.initdb.secret.name Name of the secret containing credentials for the database
+## @param postgresql.cluster.initdb.createSecret Whether to create a secret containing credentials for the database
+## @param postgresql.cluster.initdb.password PostgreSQL password
+## @param postgresql.cluster.version.postgresql PostgreSQL major version to use
+postgresql:
+  enabled: true
+  backups:
+    enabled: false
+  cluster:
+    imageName: ghcr.io/cloudnative-pg/postgresql:14.17-standard-bookworm
+    instances: 3
+    postgresql:
+      parameters:
+        shared_buffers: "512MB"
+    resources:
+      requests:
+        memory: "2Gi"
+        cpu: 1
+      limits:
+        memory: "4Gi"
+        cpu: 2
+    storage:
+      size: "8Gi"
+    initdb:
+      database: xnat
+      owner: xnat
+      secret:
+        name: pg-user-secret
+      createSecret: false
+      password: ""
+    version:
+      postgresql: "14"


### PR DESCRIPTION
Toward #23 
- replace bitnami postgresql helm chart with the CNPG operator and helm chart. Requires the operator to first be installed (this can be done with helm)
- three instances of Postgres are created by default (a primary and two replicas)
- the operator requires the credentials to be stored in a secret (it's not possible to pass them in plain text). The secret needs to be created before installing the chart
- configure the `xnat-properties.conf` file in an init container rather than as a secret. This is because we no longer know the password for postgres (it's stored in a secret)
- backups are not yet configured but CNPG should handle them for us. I can do this in a separate PR once we know where we'll store the backups
- update docs with changes
- update chart version to 0.0.8