### PR TITLE
Add CNPG repo in publish workflow before packaging the chart

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,10 @@ jobs:
         with:
           version: v3.17.0
 
+      - name: Add Helm repos for dependencies
+        run: |
+          helm repo add cnpg https://cloudnative-pg.github.io/charts
+
       - name: Lowercase repository owner
         run: echo "REPO_OWNER=${GITHUB_REPOSITORY_OWNER@L}" >> "${GITHUB_ENV}"
 


### PR DESCRIPTION
Publishing the chart currently fails to build dependencies:

> Error: no repository definition for https://cloudnative-pg.github.io/charts. Please add the missing repos via 'helm repo add'

- add the CNPG repo before building the dependencies