### PR TITLE
Configure the `openid-conf.properties` file in an init container

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,7 @@ helm template xnat-core ./xnat-0.0.9.tgz > build/chart.yaml
 | `web.siteUrl`                                             | Site URL                                                   | `""`                                                        |
 | `web.auth.openid.provider`                                | OpenID provider name                                       | `openid1`                                                   |
 | `web.auth.openid.enabled`                                 | Enable or disable the config                               | `false`                                                     |
-| `web.auth.openid.clientId`                                | OpenID client ID                                           | `""`                                                        |
-| `web.auth.openid.clientSecret`                            | OpenID client secret                                       | `""`                                                        |
+| `web.auth.openid.secretName`                              | Name of secret with clientID and clientSecret              | `openid-secret`                                             |
 | `web.auth.openid.accessTokenUri`                          | OpenID access token URI                                    | `""`                                                        |
 | `web.auth.openid.userAuthUri`                             | OpenID user authentication URI                             | `""`                                                        |
 | `web.auth.openid.link`                                    | OpenID link                                                | `""`                                                        |

--- a/chart/templates/secrets.yaml
+++ b/chart/templates/secrets.yaml
@@ -1,29 +1,3 @@
-{{- if .Values.web.auth.openid.enabled }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: openid-conf
-  labels: {{- include "xnat.labels" . | nindent 4 }}
-type: Opaque
-stringData:
-  openid-conf.properties: |
-    name="UCL SSO"
-    provider.id={{- .Values.web.auth.openid.provider }}
-    auth.method=OpenID
-    auto.enabled=false
-    auto.verified=false
-    siteUrl={{ .Values.web.siteUrl }}
-    openid.{{- .Values.web.auth.openid.provider -}}.clientId={{ .Values.web.auth.openid.clientId }}
-    openid.{{- .Values.web.auth.openid.provider -}}.clientSecret={{ .Values.web.auth.openid.clientSecret }}
-    openid.{{- .Values.web.auth.openid.provider -}}.accessTokenUri={{ .Values.web.auth.openid.accessTokenUri }}
-    openid.{{- .Values.web.auth.openid.provider -}}.userAuthUri={{ .Values.web.auth.openid.userAuthUri }}
-    openid.{{- .Values.web.auth.openid.provider -}}.link=<a href="/openid-login?providerId={{- .Values.web.auth.openid.provider -}}">{{ .Values.web.auth.openid.link }}</a>
-    openid.{{- .Values.web.auth.openid.provider -}}.forceUserCreate=true
-    openid.{{- .Values.web.auth.openid.provider -}}.emailProperty=email
-    openid.{{- .Values.web.auth.openid.provider -}}.givenNameProperty=name
-    openid.{{- .Values.web.auth.openid.provider -}}.familyNameProperty=deliberately_unknown_property
-{{- end }}
 {{ if .Values.imageCredentials.enabled }}
 ---
 apiVersion: v1

--- a/chart/templates/xnat-web-statefulset.yaml
+++ b/chart/templates/xnat-web-statefulset.yaml
@@ -136,6 +136,47 @@ spec:
           volumeMounts:
             - name: node-conf
               mountPath: /xnat
+        {{- if .Values.web.auth.openid.enabled }}
+        - name: openid-conf
+          image: {{ include "xnat.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: OPENID_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.web.auth.openid.secretName }}
+                  key: clientId
+            - name: OPENID_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.web.auth.openid.secretName }}
+                  key: clientSecret
+          command:
+            - 'bash'
+            - '-c'
+            - |
+              set -x
+              cat <<EOF > /xnat/openid-conf.properties
+              name="UCL SSO"
+              provider.id={{- .Values.web.auth.openid.provider }}
+              auth.method=OpenID
+              auto.enabled=false
+              auto.verified=false
+              siteUrl={{ .Values.web.siteUrl }}
+              openid.{{- .Values.web.auth.openid.provider -}}.clientId=$OPENID_CLIENT_ID
+              openid.{{- .Values.web.auth.openid.provider -}}.clientSecret=$OPENID_CLIENT_SECRET
+              openid.{{- .Values.web.auth.openid.provider -}}.accessTokenUri={{ .Values.web.auth.openid.accessTokenUri }}
+              openid.{{- .Values.web.auth.openid.provider -}}.userAuthUri={{ .Values.web.auth.openid.userAuthUri }}
+              openid.{{- .Values.web.auth.openid.provider -}}.link=<a href="/openid-login?providerId={{- .Values.web.auth.openid.provider -}}">{{ .Values.web.auth.openid.link }}</a>
+              openid.{{- .Values.web.auth.openid.provider -}}.forceUserCreate=true
+              openid.{{- .Values.web.auth.openid.provider -}}.emailProperty=email
+              openid.{{- .Values.web.auth.openid.provider -}}.givenNameProperty=name
+              openid.{{- .Values.web.auth.openid.provider -}}.familyNameProperty=deliberately_unknown_property
+              EOF
+          volumeMounts:
+            - name: openid-conf
+              mountPath: /xnat/openid-conf.properties
+        {{- end }}
       {{- with .Values.web.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -151,8 +192,6 @@ spec:
       volumes:
       {{- if .Values.web.auth.openid.enabled }}
         - name: xnat-openid-config
-          secret:
-            secretName: openid-conf
       {{- end }}
       {{- range .Values.volumes }}
         - name: {{ .name }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -140,8 +140,7 @@ web:
 
   ## @param web.auth.openid.provider OpenID provider name
   ## @param web.auth.openid.enabled Enable or disable the config
-  ## @param web.auth.openid.clientId OpenID client ID
-  ## @param web.auth.openid.clientSecret OpenID client secret
+  ## @param web.auth.openid.secretName Name of secret with clientID and clientSecret
   ## @param web.auth.openid.accessTokenUri OpenID access token URI
   ## @param web.auth.openid.userAuthUri OpenID user authentication URI
   ## @param web.auth.openid.link OpenID link
@@ -149,8 +148,7 @@ web:
     openid:
       provider: openid1
       enabled: false
-      clientId: ""
-      clientSecret: ""
+      secretName: openid-secret
       accessTokenUri: ""
       userAuthUri: ""
       link: ""


### PR DESCRIPTION
- move `openid-conf.properties` creation into an init container rather than a secret
- retrieve the `clientId` and `clientSecret` from a secret
- set the name of the secret with `web.auth.openid.secretName` (defaults to `openid-secret`)
