### PR TITLE
Require secret for localdb XNAT users

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Create the namespace:
 kubectl apply -f namespace.yaml
 ```
 
-### Create a secret containing Postgres credentials
+### Create a secret containing Postgres and XNAT credentials
 
 Create a manifest for the secret:
 
 ```bash
-cat <<EOF > secret.yaml
+cat <<EOF > secrets.yaml
 apiVersion: v1
 stringData:
   username: xnat
@@ -60,13 +60,23 @@ metadata:
   name: pg-user-secret
   namespace: xnat-core
 type: kubernetes.io/basic-auth
+---
+apiVersion: v1
+stringData:
+  adminPassword: strongPassword
+  serviceAdminPassword: anotherStrongPassword
+kind: Secret
+metadata:
+  name: localdb-secret
+  namespace: xnat-core
+type: kubernetes.io/basic-auth
 EOF
 ```
 
 Create the secret:
 
 ```bash
-kubectl apply -f secret.yaml --namespace xnat-core
+kubectl apply -f secrets.yaml
 ```
 
 ### Package and install `xnat-chart`
@@ -82,15 +92,11 @@ Then install the packaged chart in the cluster with the following command:
 ```shell
 helm install \
 --set image.name=xnat-core \
---set image.name=xnat-core \
---set image.tag=0.0.1 \
+--set image.tag=0.0.2 \
 --set imageCredentials.enabled=true \
 --set imageCredentials.registry=ghcr.io \
 --set imageCredentials.username=<GH_USERNAME> \
 --set imageCredentials.password=<GH_PAT> \
---set postgresql.auth.password=xnat \
---set web.config.adminPassword=<ADMIN_USER_PASSWORD> \
---set web.config.serviceAdminPassword=<SERVICE_USER_PASSWORD> \
 --namespace xnat-core \
 xnat-core xnat-0.0.10.tgz
 ```
@@ -189,6 +195,7 @@ helm template xnat-core ./xnat-0.0.10.tgz > build/chart.yaml
 | `web.auth.openid.accessTokenUri`                          | OpenID access token URI                                    | `""`                                                        |
 | `web.auth.openid.userAuthUri`                             | OpenID user authentication URI                             | `""`                                                        |
 | `web.auth.openid.link`                                    | OpenID link                                                | `""`                                                        |
+| `web.auth.localdb.secretName`                             | Name of secret with adminPassword and serviceAdminPassword | `localdb-secret`                                            |
 | `web.podAnnotations`                                      | Annotations to add to the web pod                          | `{}`                                                        |
 | `web.podLabels`                                           | Labels to add to the web pod                               | `{}`                                                        |
 | `web.podSecurityContext.runAsUser`                        | Pod security context runAsUser                             | `1000`                                                      |
@@ -227,14 +234,11 @@ helm template xnat-core ./xnat-0.0.10.tgz > build/chart.yaml
 | `web.tolerations`                                         | Tolerations to add to the web pod                          | `[]`                                                        |
 | `web.affinity`                                            | Affinity to add to the web pod                             | `{}`                                                        |
 | `web.config.enabled`                                      | Enable or disable the config                               | `true`                                                      |
-| `web.config.existingSecret`                               | Existing secret name                                       | `""`                                                        |
 | `web.config.image.pullPolicy`                             | Image pull policy                                          | `""`                                                        |
 | `web.config.image.name`                                   | Image name                                                 | `xnat-config`                                               |
 | `web.config.image.namespace`                              | Image namespace                                            | `ucl-mirsg`                                                 |
 | `web.config.image.registry`                               | Image registry                                             | `ghcr.io`                                                   |
 | `web.config.image.tag`                                    | Image tag                                                  | `latest`                                                    |
-| `web.config.adminPassword`                                | Admin password                                             | `""`                                                        |
-| `web.config.serviceAdminPassword`                         | Service admin password                                     | `""`                                                        |
 | `postgresql.enabled`                                      | Whether to deploy a PostgreSQL cluster                     | `true`                                                      |
 | `postgresql.backups.enabled`                              | Whether to enable database backups                         | `false`                                                     |
 | `postgresql.cluster.imageName`                            | Name of the PostgreSQL container image                     | `ghcr.io/cloudnative-pg/postgresql:14.17-standard-bookworm` |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ helm install \
 --set imageCredentials.username=<GH_USERNAME> \
 --set imageCredentials.password=<GH_PAT> \
 --namespace xnat-core \
-xnat-core xnat-0.0.10.tgz
+xnat-core xnat-0.0.11.tgz
 ```
 
 Set `image.tag` to the version of the
@@ -123,7 +123,7 @@ helm uninstall xnat-core -n xnat-core
 The chart can be rendered using the default values with the following command:
 
 ```shell
-helm template xnat-core ./xnat-0.0.10.tgz > build/chart.yaml
+helm template xnat-core ./xnat-0.0.11.tgz > build/chart.yaml
 ```
 
 ## Parameters

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: xnat
 description: A Helm chart for deploying XNAT on Kubernetes
 type: application
-version: 0.0.10
+version: 0.0.11
 # XNAT version deployed in the chart
 appVersion: 1.8.10
 

--- a/chart/templates/jobs.yaml
+++ b/chart/templates/jobs.yaml
@@ -28,35 +28,26 @@ spec:
       containers:
       - name: post-install-job
         image: "{{ .Values.web.config.image.registry }}/{{ .Values.web.config.image.namespace }}/{{ .Values.web.config.image.name }}:{{ .Values.web.config.image.tag }}"
-        {{- if .Values.web.config.existingSecret }}
         env:
         - name: XNAT_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.web.config.existingSecret }}
-              key: admin_password
+              name: {{ .Values.web.auth.localdb.secretName }}
+              key: adminPassword
         - name: XNAT_SERVICE_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.web.config.existingSecret }}
-              key: service_admin_password
-        {{- end }}
+              name: {{ .Values.web.auth.localdb.secretName }}
+              key: serviceAdminPassword
         command: ["ansible-playbook"]
         args:
           - configure-xnat.yaml
           - --extra-vars
           - xnat_url=http://{{ include "xnat.fullname" . }}
-          {{- if .Values.web.config.existingSecret }}
           - --extra-vars
           - xnat_admin_password=$XNAT_ADMIN_PASSWORD
           - --extra-vars
           - xnat_service_admin_password=$XNAT_SERVICE_ADMIN_PASSWORD
-          {{- else }}
-          - --extra-vars
-          - xnat_admin_password={{ .Values.web.config.adminPassword }}
-          - --extra-vars
-          - xnat_service_admin_password={{ .Values.web.config.serviceAdminPassword }}
-          {{- end }}
           {{- if .Values.web.auth.openid.enabled }}
           - --extra-vars
           - '{"xnat_enabled_providers": ["localdb", {{ .Values.web.auth.openid.provider | quote }}]}'

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -144,6 +144,7 @@ web:
   ## @param web.auth.openid.accessTokenUri OpenID access token URI
   ## @param web.auth.openid.userAuthUri OpenID user authentication URI
   ## @param web.auth.openid.link OpenID link
+  ## @param web.auth.localdb.secretName Name of secret with adminPassword and serviceAdminPassword
   auth:
     openid:
       provider: openid1
@@ -152,6 +153,8 @@ web:
       accessTokenUri: ""
       userAuthUri: ""
       link: ""
+    localdb:
+      secretName: localdb-secret
 
   ## @param web.podAnnotations Annotations to add to the web pod
   podAnnotations: {}
@@ -270,25 +273,19 @@ web:
   affinity: {}
 
   ## @param web.config.enabled Enable or disable the config
-  ## @param web.config.existingSecret Existing secret name
   ## @param web.config.image.pullPolicy Image pull policy
   ## @param web.config.image.name Image name
   ## @param web.config.image.namespace Image namespace
   ## @param web.config.image.registry Image registry
   ## @param web.config.image.tag Image tag
-  ## @param web.config.adminPassword Admin password
-  ## @param web.config.serviceAdminPassword Service admin password
   config:
     enabled: true
-    existingSecret: ""
     image:
       pullPolicy: ""
       name: xnat-config
       namespace: ucl-mirsg
       registry: ghcr.io
       tag: latest
-    adminPassword: ""
-    serviceAdminPassword: ""
 
 ### @section XNAT Database parameters
 ## @param postgresql.enabled Whether to deploy a PostgreSQL cluster


### PR DESCRIPTION
Require credentials for localdb XNAT users to be stored in a secret (so that we handle credentials in a consistent way, i.e. we require openid NXAT credentials and postgres credentials to be stored in secrets).

- remove `web.config.adminPassword` and `web.config.serviceAdminPassword`
- add `web.auth.localdb.secretName` to set the name of a secret that must contain the keys `adminPassword` and `serviceAdminPassword`. Default to `localdb-secret`
- update docs
- bump chart version to 0.0.11
