### PR TITLE
Add option to override default `CATALINA_OPTS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ helm template xnat-core ./xnat-0.0.11.tgz > build/chart.yaml
 | `web.nodeSelector`                                        | Node selector                                              | `{}`                                                        |
 | `web.tolerations`                                         | Tolerations to add to the web pod                          | `[]`                                                        |
 | `web.affinity`                                            | Affinity to add to the web pod                             | `{}`                                                        |
+| `web.tomcat.catalinaOpts`                                 | Override default CATALINA_OPTS                             | `""`                                                        |
 | `web.config.enabled`                                      | Enable or disable the config                               | `true`                                                      |
 | `web.config.image.pullPolicy`                             | Image pull policy                                          | `""`                                                        |
 | `web.config.image.name`                                   | Image name                                                 | `xnat-config`                                               |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ helm install \
 --set imageCredentials.username=<GH_USERNAME> \
 --set imageCredentials.password=<GH_PAT> \
 --namespace xnat-core \
-xnat-core xnat-0.0.11.tgz
+xnat-core xnat-0.0.12.tgz
 ```
 
 Set `image.tag` to the version of the
@@ -123,7 +123,7 @@ helm uninstall xnat-core -n xnat-core
 The chart can be rendered using the default values with the following command:
 
 ```shell
-helm template xnat-core ./xnat-0.0.11.tgz > build/chart.yaml
+helm template xnat-core ./xnat-0.0.12.tgz > build/chart.yaml
 ```
 
 ## Parameters

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: xnat
 description: A Helm chart for deploying XNAT on Kubernetes
 type: application
-version: 0.0.11
+version: 0.0.12
 # XNAT version deployed in the chart
 appVersion: 1.8.10
 

--- a/chart/templates/xnat-web-statefulset.yaml
+++ b/chart/templates/xnat-web-statefulset.yaml
@@ -39,6 +39,11 @@ spec:
             {{- toYaml .Values.web.securityContext | nindent 12 }}
           image: {{ include "xnat.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.web.tomcat.catalinaOpts }}
+          env:
+            - name: CATALINA_OPTS
+              value: {{ .Values.web.tomcat.catalinaOpts | quote }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -272,6 +272,10 @@ web:
   ## @param web.affinity Affinity to add to the web pod
   affinity: {}
 
+  ## @param web.tomcat.catalinaOpts Override default CATALINA_OPTS
+  tomcat:
+    catalinaOpts: ""
+
   ## @param web.config.enabled Enable or disable the config
   ## @param web.config.image.pullPolicy Image pull policy
   ## @param web.config.image.name Image name


### PR DESCRIPTION
Fixes #5 

- add value `web.tomcat.catalinaOpts`. Defaults to an empty string.
- if set, will be used to set the `CATALINA_OPTS` environment variable in the XNAT container
- bump chart version to 0.0.12
