### PR TITLE
Add unit tests for chart

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Run helm unittest
         run: |
-          docker run -ti --rm -v $(pwd)/chart:/apps/chart helmunittest/helm-unittest:3.11.1-0.3.0 /apps/chart
+          docker run -ti --rm -v "$(pwd)/chart":/apps/chart helmunittest/helm-unittest:3.11.1-0.3.0 /apps/chart

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Run helm unittest
         run: |
-          docker run -ti --rm -v "$(pwd)/chart":/apps/chart helmunittest/helm-unittest:3.11.1-0.3.0 /apps/chart
+          docker run --rm -v "$(pwd)/chart":/apps/chart helmunittest/helm-unittest:3.11.1-0.3.0 /apps/chart

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,31 @@
+---
+name: Helm unittest
+
+on:
+  push:
+    branches:
+      - main
+      - renovate/**
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+
+concurrency:
+  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  helm-unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Run helm unittest
+        run: |
+          docker run -ti --rm -v $(pwd)/chart:/apps/chart helmunittest/helm-unittest:3.11.1-0.3.0 /apps/chart

--- a/README.md
+++ b/README.md
@@ -126,6 +126,84 @@ The chart can be rendered using the default values with the following command:
 helm template xnat-core ./xnat-0.0.12.tgz > build/chart.yaml
 ```
 
+## Unit tests
+
+We are using the
+[Helm Unittest plugin](https://github.com/helm-unittest/helm-unittest) for
+regression testing the chart templates.
+
+### Running the tests
+
+You can use the Helm Unittest
+[docker image](https://hub.docker.com/r/helmunittest/helm-unittest/) to run the
+tests.
+
+From the top-level directory of this repo:
+
+```bash
+docker run -it --rm -v "$(pwd)/chart":/apps/chart helmunittest/helm-unittest /apps/chart
+```
+
+This will run all the tests in the [`charts/tests`](./chart/tests/) folder,
+comparing the rendered templates to those in
+[`charts/tests/__shapshot__`](./chart/tests/__snapshot__/).
+
+### Adding a new test
+
+To add a new test, add a YAML file to the[`charts/tests`](./chart/tests/)
+directory. The filename must end in `_test.yaml`, e.g. `manifest_test.yaml`.
+
+#### Rendering the whole template
+
+To render the entire template:
+
+```yaml
+templates:
+  - templates/manifest.yaml # path to your template to test
+tests:
+  - it: manifest should match snapshot
+    asserts:
+      - matchSnapshot: {} # render and compare all fields in the template
+```
+
+The first time you run the test, the template will be rendered and stored in the
+[`charts/test/__snapshot__`](./chart/tests/__snapshot__/) directory. This
+snapshot will then be used for regression testing in future test runs.
+
+#### Rendering specific fields
+
+To render specific fields in the the template:
+
+```yaml .yaml
+templates:
+  - templates/manifest.yaml # path to your template to test
+tests:
+  - it: manifest should match snapshot
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec # path to a field you would like rendered in the snapshot
+      - matchSnapshot:
+          path: spec.volumeClaimTemplates # path to another field you would like rendered in the snapshot
+```
+
+This is useful if other parts of the template contain information that will
+change often, e.g. the release version of this chart.
+
+#### Set template values
+
+To set values when rendering the template:
+
+```yaml
+templates:
+  - templates/manifest.yaml # path to your template to test
+tests:
+  - it: manifest should match snapshot
+    set:
+      web.config.enabled: true # override a default chart value
+    asserts:
+      - matchSnapshot: {}
+```
+
 ## Parameters
 
 ### Common parameters

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ snapshot will then be used for regression testing in future test runs.
 
 To render specific fields in the the template:
 
-```yaml .yaml
+```yaml
 templates:
   - templates/manifest.yaml # path to your template to test
 tests:

--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ tests:
       - matchSnapshot: {}
 ```
 
+#### Updating snapshots
+
+To update the snapshots, run the tests with the `-u` flag:
+
+```bash
+docker run -it --rm -v "$(pwd)/chart":/apps/chart helmunittest/helm-unittest:3.11.1-0.3.0 /apps/chart -u
+```
+
 ## Parameters
 
 ### Common parameters

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+
+tests

--- a/chart/tests/NOTES_test.yaml
+++ b/chart/tests/NOTES_test.yaml
@@ -1,0 +1,9 @@
+templates:
+  - NOTES.txt
+
+tests:
+  - it: notes should match snapshot
+    set:
+      web.ingress.enabled: true
+    asserts:
+      - matchSnapshotRaw: {}

--- a/chart/tests/__snapshot__/NOTES_test.yaml.snap
+++ b/chart/tests/__snapshot__/NOTES_test.yaml.snap
@@ -1,0 +1,5 @@
+notes should match snapshot:
+  1: |
+    |
+      1. Get the application URL by running these commands:
+        http://chart-example.local/

--- a/chart/tests/__snapshot__/ingress_test.yaml.snap
+++ b/chart/tests/__snapshot__/ingress_test.yaml.snap
@@ -1,0 +1,14 @@
+ingress manifest should match snapshot:
+  1: |
+    ingressClassName: null
+    rules:
+      - host: chart-example.local
+        http:
+          paths:
+            - backend:
+                service:
+                  name: RELEASE-NAME-xnat-headless
+                  port:
+                    number: 80
+              path: /
+              pathType: Prefix

--- a/chart/tests/__snapshot__/ingress_test.yaml.snap
+++ b/chart/tests/__snapshot__/ingress_test.yaml.snap
@@ -1,6 +1,6 @@
 ingress manifest should match snapshot:
   1: |
-    ingressClassName: null
+    ingressClassName: nginx
     rules:
       - host: chart-example.local
         http:

--- a/chart/tests/__snapshot__/jobs_test.yaml.snap
+++ b/chart/tests/__snapshot__/jobs_test.yaml.snap
@@ -1,0 +1,31 @@
+jobs manifest should match snapshot:
+  1: |
+    backoffLimit: 0
+    containers:
+      - args:
+          - configure-xnat.yaml
+          - --extra-vars
+          - xnat_url=http://RELEASE-NAME-xnat
+          - --extra-vars
+          - xnat_admin_password=$XNAT_ADMIN_PASSWORD
+          - --extra-vars
+          - xnat_service_admin_password=$XNAT_SERVICE_ADMIN_PASSWORD
+          - -v
+        command:
+          - ansible-playbook
+        env:
+          - name: XNAT_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: adminPassword
+                name: localdb-secret
+          - name: XNAT_SERVICE_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: serviceAdminPassword
+                name: localdb-secret
+        image: ghcr.io/ucl-mirsg/xnat-config:latest
+        name: post-install-job
+    imagePullSecrets:
+      - name: ""
+    restartPolicy: Never

--- a/chart/tests/__snapshot__/secrets_test.yaml.snap
+++ b/chart/tests/__snapshot__/secrets_test.yaml.snap
@@ -1,0 +1,9 @@
+secrets manifest should match snapshot:
+  1: |
+    apiVersion: v1
+    data:
+      .dockerconfigjson: eyJhdXRocyI6eyIiOnsidXNlcm5hbWUiOiIiLCJwYXNzd29yZCI6IiIsImVtYWlsIjoiIiwiYXV0aCI6Ik9nPT0ifX19
+    kind: Secret
+    metadata:
+      name: image-pull-secret
+    type: kubernetes.io/dockerconfigjson

--- a/chart/tests/__snapshot__/service_test.yaml.snap
+++ b/chart/tests/__snapshot__/service_test.yaml.snap
@@ -1,0 +1,23 @@
+service manifest should match snapshot:
+  1: |
+    ports:
+      - name: http
+        port: 80
+        protocol: TCP
+        targetPort: 8080
+    selector:
+      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/name: xnat
+    type: ClusterIP
+  2: |
+    clusterIP: None
+    ports:
+      - name: http
+        port: 80
+        protocol: TCP
+        targetPort: 8080
+    selector:
+      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/name: xnat
+    sessionAffinity: ClientIP
+    type: ClusterIP

--- a/chart/tests/__snapshot__/serviceaccount_test.yaml.snap
+++ b/chart/tests/__snapshot__/serviceaccount_test.yaml.snap
@@ -1,0 +1,3 @@
+serviceaccount manifest should match snapshot:
+  1: |
+    RELEASE-NAME-xnat

--- a/chart/tests/__snapshot__/xnat-web-statefulset_test.yaml.snap
+++ b/chart/tests/__snapshot__/xnat-web-statefulset_test.yaml.snap
@@ -1,0 +1,200 @@
+xnat-web-statefulst manifest should match snapshot:
+  1: |
+    containers:
+      - command:
+          - /bin/sh
+          - -c
+          - |
+            /usr/local/tomcat/bin/catalina.sh run
+        image: ghcr.io/ucl-mirsg/:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 1
+          httpGet:
+            path: /app/template/Login.vm#!
+            port: http
+          periodSeconds: 10
+          timeoutSeconds: 5
+        name: xnat
+        ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+        readinessProbe:
+          failureThreshold: 1
+          httpGet:
+            path: /app/template/Login.vm#!
+            port: http
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 2
+            memory: 4000Mi
+          requests:
+            cpu: 1
+            memory: 4000Mi
+        securityContext: {}
+        startupProbe:
+          failureThreshold: 15
+          httpGet:
+            path: /app/template/Login.vm#!
+            port: http
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        volumeMounts:
+          - mountPath: /data/xnat/home/config/auth/openid-conf.properties
+            name: xnat-openid-config
+            readOnly: true
+            subPath: openid-conf.properties
+          - mountPath: /data/xnat/home/config/node-conf.properties
+            name: node-conf
+            subPath: node-conf.properties
+          - mountPath: /data/xnat/archive
+            name: xnat-archive
+            subPath: null
+          - mountPath: /data/xnat/home/config/xnat-conf.properties
+            name: xnat-config
+            subPath: xnat-conf.properties
+          - mountPath: /data/xnat/prearchive
+            name: xnat-prearchive
+            subPath: null
+    imagePullSecrets:
+      - name: ""
+    initContainers:
+      - command:
+          - bash
+          - -c
+          - |
+            set -e
+            until psql -h RELEASE-NAME-postgresql-rw -c '\q'; do
+              >&2 echo "Postgres is unavailable - sleeping"
+              sleep 30
+            done
+            >&2 echo "Postgres is up"
+        env:
+          - name: PGUSER
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: pg-user-secret
+          - name: PGPASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: pg-user-secret
+        image: ghcr.io/ucl-mirsg/:latest
+        imagePullPolicy: IfNotPresent
+        name: wait-for-postgres
+      - command:
+          - bash
+          - -c
+          - |
+            set -x
+            cat <<EOF > /xnat/xnat-conf.properties
+            datasource.driver=org.postgresql.Driver
+            datasource.url=jdbc:postgresql://RELEASE-NAME-postgresql-rw/xnat
+            datasource.username=$XNAT_DATASOURCE_USERNAME
+            datasource.password=$XNAT_DATASOURCE_PASSWORD
+            hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
+            hibernate.hbm2ddl.auto=update
+            hibernate.show_sql=false
+            hibernate.cache.use_second_level_cache=true
+            hibernate.cache.use_query_cache=true
+            EOF
+        env:
+          - name: XNAT_DATASOURCE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: pg-user-secret
+          - name: XNAT_DATASOURCE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: pg-user-secret
+        image: ghcr.io/ucl-mirsg/:latest
+        imagePullPolicy: IfNotPresent
+        name: xnat-datasource
+        volumeMounts:
+          - mountPath: /xnat
+            name: xnat-config
+      - command:
+          - bash
+          - -c
+          - |
+            set -x
+            echo "node.id=$HOSTNAME" > /xnat/node-conf.properties
+        image: ghcr.io/ucl-mirsg/:latest
+        imagePullPolicy: IfNotPresent
+        name: node-conf
+        volumeMounts:
+          - mountPath: /xnat
+            name: node-conf
+      - command:
+          - bash
+          - -c
+          - |
+            set -x
+            cat <<EOF > /xnat/openid-conf.properties
+            name="UCL SSO"
+            provider.id=openid1
+            auth.method=OpenID
+            auto.enabled=false
+            auto.verified=false
+            siteUrl=
+            openid.openid1.clientId=$OPENID_CLIENT_ID
+            openid.openid1.clientSecret=$OPENID_CLIENT_SECRET
+            openid.openid1.accessTokenUri=
+            openid.openid1.userAuthUri=
+            openid.openid1.link=<a href="/openid-login?providerId=openid1"></a>
+            openid.openid1.forceUserCreate=true
+            openid.openid1.emailProperty=email
+            openid.openid1.givenNameProperty=name
+            openid.openid1.familyNameProperty=deliberately_unknown_property
+            EOF
+        env:
+          - name: OPENID_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: clientId
+                name: openid-secret
+          - name: OPENID_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: clientSecret
+                name: openid-secret
+        image: ghcr.io/ucl-mirsg/:latest
+        imagePullPolicy: IfNotPresent
+        name: openid-conf
+        volumeMounts:
+          - mountPath: /xnat/openid-conf.properties
+            name: openid-conf
+    securityContext:
+      runAsUser: 1000
+    serviceAccountName: RELEASE-NAME-xnat
+    volumes:
+      - name: xnat-openid-config
+      - emptyDir: {}
+        name: node-conf
+      - name: xnat-archive
+      - emptyDir: {}
+        name: xnat-config
+      - name: xnat-prearchive
+  2: |
+    - metadata:
+        name: xnat-archive
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 8Gi
+    - metadata:
+        name: xnat-prearchive
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 8Gi

--- a/chart/tests/__snapshot__/xnat-web-statefulset_test.yaml.snap
+++ b/chart/tests/__snapshot__/xnat-web-statefulset_test.yaml.snap
@@ -6,7 +6,7 @@ xnat-web-statefulst manifest should match snapshot:
           - -c
           - |
             /usr/local/tomcat/bin/catalina.sh run
-        image: ghcr.io/ucl-mirsg/:latest
+        image: ghcr.io/ucl-mirsg/xnat-core:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1
@@ -83,7 +83,7 @@ xnat-web-statefulst manifest should match snapshot:
               secretKeyRef:
                 key: password
                 name: pg-user-secret
-        image: ghcr.io/ucl-mirsg/:latest
+        image: ghcr.io/ucl-mirsg/xnat-core:latest
         imagePullPolicy: IfNotPresent
         name: wait-for-postgres
       - command:
@@ -113,7 +113,7 @@ xnat-web-statefulst manifest should match snapshot:
               secretKeyRef:
                 key: password
                 name: pg-user-secret
-        image: ghcr.io/ucl-mirsg/:latest
+        image: ghcr.io/ucl-mirsg/xnat-core:latest
         imagePullPolicy: IfNotPresent
         name: xnat-datasource
         volumeMounts:
@@ -125,7 +125,7 @@ xnat-web-statefulst manifest should match snapshot:
           - |
             set -x
             echo "node.id=$HOSTNAME" > /xnat/node-conf.properties
-        image: ghcr.io/ucl-mirsg/:latest
+        image: ghcr.io/ucl-mirsg/xnat-core:latest
         imagePullPolicy: IfNotPresent
         name: node-conf
         volumeMounts:
@@ -164,7 +164,7 @@ xnat-web-statefulst manifest should match snapshot:
               secretKeyRef:
                 key: clientSecret
                 name: openid-secret
-        image: ghcr.io/ucl-mirsg/:latest
+        image: ghcr.io/ucl-mirsg/xnat-core:latest
         imagePullPolicy: IfNotPresent
         name: openid-conf
         volumeMounts:

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -4,7 +4,7 @@ tests:
   - it: ingress manifest should match snapshot
     set:
       web.ingress.enabled: true
-      web.ingress.classname: nginx
+      web.ingress.className: nginx
     asserts:
       - matchSnapshot:
           path: spec

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -1,0 +1,9 @@
+templates:
+  - templates/ingress.yaml
+tests:
+  - it: ingress manifest should match snapshot
+    set:
+      web.ingress.enabled: true
+    asserts:
+      - matchSnapshot:
+          path: spec

--- a/chart/tests/ingress_test.yaml
+++ b/chart/tests/ingress_test.yaml
@@ -4,6 +4,7 @@ tests:
   - it: ingress manifest should match snapshot
     set:
       web.ingress.enabled: true
+      web.ingress.classname: nginx
     asserts:
       - matchSnapshot:
           path: spec

--- a/chart/tests/jobs_test.yaml
+++ b/chart/tests/jobs_test.yaml
@@ -1,0 +1,9 @@
+templates:
+  - templates/jobs.yaml
+tests:
+  - it: jobs manifest should match snapshot
+    set:
+      web.config.enabled: true
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec

--- a/chart/tests/secrets_test.yaml
+++ b/chart/tests/secrets_test.yaml
@@ -1,0 +1,9 @@
+templates:
+  - templates/secrets.yaml
+
+tests:
+  - it: secrets manifest should match snapshot
+    set:
+      imageCredentials.enabled: true
+    asserts:
+      - matchSnapshot: {}

--- a/chart/tests/service_test.yaml
+++ b/chart/tests/service_test.yaml
@@ -1,0 +1,8 @@
+templates:
+  - templates/service.yaml
+
+tests:
+  - it: service manifest should match snapshot
+    asserts:
+      - matchSnapshot:
+          path: spec

--- a/chart/tests/serviceaccount_test.yaml
+++ b/chart/tests/serviceaccount_test.yaml
@@ -1,0 +1,10 @@
+templates:
+  - templates/serviceaccount.yaml
+
+tests:
+  - it: serviceaccount manifest should match snapshot
+    set:
+      serviceAccount.create: true
+    asserts:
+      - matchSnapshot:
+          path: metadata.name

--- a/chart/tests/xnat-web-statefulset_test.yaml
+++ b/chart/tests/xnat-web-statefulset_test.yaml
@@ -1,0 +1,12 @@
+templates:
+  - templates/xnat-web-statefulset.yaml
+
+tests:
+  - it: xnat-web-statefulst manifest should match snapshot
+    set:
+      web.auth.openid.enabled: true
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec
+      - matchSnapshot:
+          path: spec.volumeClaimTemplates

--- a/chart/tests/xnat-web-statefulset_test.yaml
+++ b/chart/tests/xnat-web-statefulset_test.yaml
@@ -4,6 +4,7 @@ templates:
 tests:
   - it: xnat-web-statefulst manifest should match snapshot
     set:
+      image.name: xnat-core
       web.auth.openid.enabled: true
     asserts:
       - matchSnapshot:


### PR DESCRIPTION
Fixes #20 

- add tests using [helm unittest](https://github.com/quintush/helm-unittest) to check that manifests are rendered correctly from the templates
- add snapshots of current manifests that will be used for future regression testing. Don't compare any paths that contain the `xnat-chart` release version, otherwise we'd need to update the snapshots everytime the version is updated
- add a workflow to run the unittests