### PR TITLE
Use `ct` for chart testing

### DIFF
--- a/.github/workflows/chart-tests.yaml
+++ b/.github/workflows/chart-tests.yaml
@@ -1,0 +1,72 @@
+---
+name: Helm Chart Testing
+
+on:
+  push:
+    branches:
+      - main
+      - renovate/**
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+
+concurrency:
+  cancel-in-progress: true
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  helm-chart-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+        with:
+          python-version: 3.x
+
+      - name: Create kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          config: chart/ci/kind-config.yaml
+          cluster-name: xnat
+          wait: 120s
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: v3.17.0
+
+      - name: Install CNPG operator
+        run: |
+          helm repo add cnpg https://cloudnative-pg.github.io/charts
+          helm repo update
+          helm upgrade --install cnpg \
+            --namespace cnpg-system \
+            --create-namespace \
+            cnpg/cloudnative-pg
+
+      - name: Create required resources
+        run: |
+          kubectl apply -f chart/ci/manifests/namespace.yaml
+          kubectl apply -f chart/ci/manifests/secrets.yaml
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+
+      - name: Run chart-testing (install)
+        run: >-
+          ct install --config ct.yaml --helm-extra-set-args="
+            --set imageCredentials.username=${{ secrets.GH_USER }}
+            --set imageCredentials.password=${{ secrets.GH_PAT }}
+            "

--- a/.github/workflows/chart-tests.yaml
+++ b/.github/workflows/chart-tests.yaml
@@ -87,6 +87,6 @@ jobs:
       - name: Run chart-testing (install)
         run: >-
           ct install --config ct.yaml --helm-extra-set-args="
-            --set imageCredentials.username=${{ secrets.GH_USER }}
-            --set imageCredentials.password=${{ secrets.GH_PAT }}
+            --set imageCredentials.username=${{ secrets.GHCR_USER }}
+            --set imageCredentials.password=${{ secrets.GHCR_PAT }}
             "

--- a/.github/workflows/chart-tests.yaml
+++ b/.github/workflows/chart-tests.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           config: chart/ci/kind-config.yaml
-          cluster-name: xnat
+          cluster_name: xnat
           wait: 120s
 
       - name: Install kubectl

--- a/.github/workflows/chart-tests.yaml
+++ b/.github/workflows/chart-tests.yaml
@@ -39,12 +39,15 @@ jobs:
           cluster-name: xnat
           wait: 120s
 
+      - name: Install kubectl
+        uses: azure/setup-kubectl@0c5e050edfed71b2b50731ab044d42489d51c129 # v4.0.0
+
       - name: Set up Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.17.0
 
-      - name: Install CNPG operator
+      - name: Install CNPG operator and wait for pods to be ready
         run: |
           helm repo add cnpg https://cloudnative-pg.github.io/charts
           helm repo update
@@ -52,6 +55,23 @@ jobs:
             --namespace cnpg-system \
             --create-namespace \
             cnpg/cloudnative-pg
+          kubectl wait --for=condition=Ready pod \
+            --all \
+            --namespace cnpg-system \
+            --timeout=300s
+
+      - name: Install NGINX Ingress Controller and wait for pods to be ready
+        run: |
+          helm repo add nginx https://kubernetes.github.io/ingress-nginx/
+          helm repo update
+          helm upgrade --install nginx \
+              --namespace nginx-ingress \
+              --create-namespace \
+              nginx/ingress-nginx
+          kubectl wait --for=condition=Ready pod \
+            --all \
+            --namespace nginx-ingress \
+            --timeout=300s
 
       - name: Create required resources
         run: |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ apiVersion: v1
 stringData:
   username: xnat
   password: xnat
+  dbname: xnat
 kind: Secret
 metadata:
   name: pg-user-secret
@@ -98,7 +99,7 @@ helm install \
 --set imageCredentials.username=<GH_USERNAME> \
 --set imageCredentials.password=<GH_PAT> \
 --namespace xnat-core \
-xnat-core xnat-0.0.16.tgz
+xnat-core xnat-0.0.17.tgz
 ```
 
 Set `image.tag` to the version of the
@@ -123,7 +124,7 @@ helm uninstall xnat-core -n xnat-core
 The chart can be rendered using the default values with the following command:
 
 ```shell
-helm template xnat-core ./xnat-0.0.16.tgz > build/chart.yaml
+helm template xnat-core ./xnat-0.0.17.tgz > build/chart.yaml
 ```
 
 ## Unit tests

--- a/README.md
+++ b/README.md
@@ -170,8 +170,19 @@ like to keep the chart installed, pass the `--skip-clean-up` flag to `ct`:
 ct install --skip-clean-up --config ct.yaml --helm-extra-set-args=" --set imageCredentials.username=$GH_USER --set imageCredentials.password=$GH_PAT"
 ```
 
-If you would like to uninstall the chart manually, first check the name of the
-installed chart:
+This is useful if you would like to e.g. log into the XNAT UI. To do so, you
+will first need to forward the NGINX ingress controller port to your localhost:
+
+```bash
+kubectl port-forward --namespace=nginx-ingress service/nginx-ingress-nginx-controller 8080:80
+```
+
+You can then go to `localhost:8080` in your browser and log in with the username
+`mirsg_service` and the `serviceAdminPassword` password set in the test
+[`secrets.yaml` file](./chart/ci/manifests/secrets.yaml).
+
+If you would like to uninstall the chart, first check the name of the installed
+chart:
 
 ```bash
 helm list -n xnat-core

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ By default, `ct` will uninstall the chart after the tests pass. If you would
 like to keep the chart installed, pass the `--skip-clean-up` flag to `ct`:
 
 ```bash
-ct install --skip-clean-up --config ct.yaml --helm-extra-set-args=" --set imageCredentials.username=$GH_USER s--set imageCredentials.password=$GH_PAT"
+ct install --skip-clean-up --config ct.yaml --helm-extra-set-args=" --set imageCredentials.username=$GH_USER --set imageCredentials.password=$GH_PAT"
 ```
 
 If you would like to uninstall the chart manually, first check the name of the

--- a/README.md
+++ b/README.md
@@ -1,131 +1,6 @@
 # xnat
 
-Helm Chart for XNAT
-
-## Local Installation
-
-### Create a local cluster
-
-Create a cluster into which the chart will be installed using your preferred
-method. For example, using [kind](https://kind.sigs.k8s.io/):
-
-```shell
-kind create cluster --name xnat
-```
-
-### Install the CNPG Operator
-
-We use the [CNPG Operator](https://github.com/cloudnative-pg/cloudnative-pg) to
-deploy Postgres. The operator can be installed using Helm:
-
-```bash
-helm repo add cnpg https://cloudnative-pg.github.io/charts
-helm upgrade --install cnpg \
-  --namespace cnpg-system \
-  --create-namespace \
-  cnpg/cloudnative-pg
-```
-
-### Create a namespace to install the chart
-
-Create a manifest for the namespace:
-
-```bash
-cat <<EOF > namespace.yaml
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: xnat-core
-EOF
-```
-
-Create the namespace:
-
-```bash
-kubectl apply -f namespace.yaml
-```
-
-### Create a secret containing Postgres and XNAT credentials
-
-Create a manifest for the secret:
-
-```bash
-cat <<EOF > secrets.yaml
-apiVersion: v1
-stringData:
-  username: xnat
-  password: xnat
-  dbname: xnat
-kind: Secret
-metadata:
-  name: pg-user-secret
-  namespace: xnat-core
-type: kubernetes.io/basic-auth
----
-apiVersion: v1
-stringData:
-  adminPassword: strongPassword
-  serviceAdminPassword: anotherStrongPassword
-kind: Secret
-metadata:
-  name: localdb-secret
-  namespace: xnat-core
-type: kubernetes.io/basic-auth
-EOF
-```
-
-Create the secret:
-
-```bash
-kubectl apply -f secrets.yaml
-```
-
-### Package and install `xnat-chart`
-
-To install a local copy of the chart, first create a package:
-
-```shell
-helm package --dependency-update chart
-```
-
-Then install the packaged chart in the cluster with the following command:
-
-```shell
-helm install \
---set image.name=xnat-core \
---set image.tag=0.0.2 \
---set imageCredentials.enabled=true \
---set imageCredentials.registry=ghcr.io \
---set imageCredentials.username=<GH_USERNAME> \
---set imageCredentials.password=<GH_PAT> \
---namespace xnat-core \
-xnat-core xnat-0.0.17.tgz
-```
-
-Set `image.tag` to the version of the
-[XNAT image](https://github.com/UCL-MIRSG/xnat-image/pkgs/container/xnat-core)
-you would like to use.
-
-[Create a PAT](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)
-with `read:packages` scope. Use the PAT to set `imageCredentials.password`.
-
-Set `imageCredential.username` to be your GitHub username.
-
-### Uninstall the chart
-
-Uninstall the chart using the following command:
-
-```shell
-helm uninstall xnat-core -n xnat-core
-```
-
-### Render the chart
-
-The chart can be rendered using the default values with the following command:
-
-```shell
-helm template xnat-core ./xnat-0.0.17.tgz > build/chart.yaml
-```
+Helm Chart for XNAT.
 
 ## Unit tests
 
@@ -211,6 +86,110 @@ To update the snapshots, run the tests with the `-u` flag:
 
 ```bash
 docker run -it --rm -v "$(pwd)/chart":/apps/chart helmunittest/helm-unittest:3.11.1-0.3.0 /apps/chart -u
+```
+
+## Integration tests
+
+We use [`ct`](https://github.com/helm/chart-testing) for testing the chart in
+CI.
+
+To run `ct` locally, you will need to:
+
+- create a local cluster
+- install the CNPG operator
+- create the required resources
+- setup credentials for `ghcr.io/ucl-mirsg`
+- run `ct`
+
+### Create a local cluster
+
+Create a cluster into which the chart will be installed using your preferred
+method. For example, using [kind](https://kind.sigs.k8s.io/):
+
+```shell
+kind create cluster --name xnat --config chart/ci/kind-config.yaml
+```
+
+### Install the CNPG Operator
+
+We use the [CNPG Operator](https://github.com/cloudnative-pg/cloudnative-pg) to
+deploy Postgres. The operator can be installed using Helm:
+
+```bash
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+helm upgrade --install cnpg \
+  --namespace cnpg-system \
+  --create-namespace \
+  cnpg/cloudnative-pg
+```
+
+### Create a namespace and to install the chart
+
+Create the namespace:
+
+```bash
+kubectl apply -f chart/ci/manifests/namespace.yaml
+```
+
+### Create a secret containing Postgres and XNAT credentials
+
+Create the secret:
+
+```bash
+kubectl apply -f chart/ci/manifests/secrets.yaml
+```
+
+### Setup credentials for GHCR
+
+You will need to configure credentials to pull the `xnat-image` image from our
+container registry (`ghcr.io/ucl-mirsg`).
+
+[Create a PAT](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic)
+with `read:packages` scope.
+
+### Run `ct`
+
+To run the tests using `ct`:
+
+```bash
+ct install --config ct.yaml --helm-extra-set-args="--set imageCredentials.username=$GH_USER --set imageCredentials.password=$GH_PAT"
+```
+
+Use the PAT you created [above](#setup-credentials-for-ghcr) to set
+`imageCredentials.password`.
+
+Set `imageCredential.username` to be your GitHub username.
+
+#### Keep the chart installed
+
+By default, `ct` will uninstall the chart after the tests pass. If you would
+like to keep the chart installed, pass the `--skip-clean-up` flag to `ct`:
+
+```bash
+ct install --skip-clean-up --config ct.yaml --helm-extra-set-args=" --set imageCredentials.username=$GH_USER s--set imageCredentials.password=$GH_PAT"
+```
+
+If you would like to uninstall the chart manually, first check the name of the
+installed chart:
+
+```bash
+helm list -n xnat-core
+```
+
+and make a note of the `NAME`. Then uninstall the chart:
+
+```shell
+helm uninstall <NAME> -n xnat-core
+```
+
+## Render the default chart values
+
+The chart can be rendered using the default values with the following commands:
+
+```shell
+helm package --dependency-update chart
+helm template xnat-core ./xnat-0.0.17.tgz > build/chart.yaml
 ```
 
 ## Storage

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: xnat
 description: A Helm chart for deploying XNAT on Kubernetes
 type: application
-version: 0.0.16
+version: 0.0.17
 # XNAT version deployed in the chart
 appVersion: 1.8.10
 

--- a/chart/ci/kind-config.yaml
+++ b/chart/ci/kind-config.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker

--- a/chart/ci/manifests/namespace.yaml
+++ b/chart/ci/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: xnat-core

--- a/chart/ci/manifests/secrets.yaml
+++ b/chart/ci/manifests/secrets.yaml
@@ -11,6 +11,17 @@ type: kubernetes.io/basic-auth
 ---
 apiVersion: v1
 stringData:
+  username: xnatuser
+  password: xnatpass
+  dbname: xnatdb
+kind: Secret
+metadata:
+  name: xnat-core-db-app
+  namespace: xnat-core
+type: kubernetes.io/basic-auth
+---
+apiVersion: v1
+stringData:
   adminPassword: strongPassword
   serviceAdminPassword: anotherStrongPassword
 kind: Secret

--- a/chart/ci/manifests/secrets.yaml
+++ b/chart/ci/manifests/secrets.yaml
@@ -16,7 +16,7 @@ stringData:
   dbname: xnatdb
 kind: Secret
 metadata:
-  name: xnat-core-db-app
+  name: xnat-core-app
   namespace: xnat-core
 type: kubernetes.io/basic-auth
 ---

--- a/chart/ci/manifests/secrets.yaml
+++ b/chart/ci/manifests/secrets.yaml
@@ -16,7 +16,7 @@ stringData:
   dbname: xnatdb
 kind: Secret
 metadata:
-  name: xnat-core-app
+  name: xnat-core-postgresql-app
   namespace: xnat-core
 type: kubernetes.io/basic-auth
 ---

--- a/chart/ci/manifests/secrets.yaml
+++ b/chart/ci/manifests/secrets.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+stringData:
+  username: xnatuser
+  password: xnatpass
+  dbname: xnatdb
+kind: Secret
+metadata:
+  name: pg-user-secret
+  namespace: xnat-core
+type: kubernetes.io/basic-auth
+---
+apiVersion: v1
+stringData:
+  adminPassword: strongPassword
+  serviceAdminPassword: anotherStrongPassword
+kind: Secret
+metadata:
+  name: localdb-secret
+  namespace: xnat-core
+type: kubernetes.io/opaque

--- a/chart/ci/test-values.yaml
+++ b/chart/ci/test-values.yaml
@@ -12,7 +12,7 @@ imageCredentials:
   registry: ghcr.io
 
 postgresql:
-  fullnameOverride: xnat-core
+  fullnameOverride: xnat-core-postgresql
   cluster:
     initdb:
       database: xnatdb

--- a/chart/ci/test-values.yaml
+++ b/chart/ci/test-values.yaml
@@ -17,7 +17,28 @@ postgresql:
     initdb:
       database: xnatdb
       owner: xnatuser
+
 web:
   siteUrl: http://localhost
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+      nginx.ingress.kubernetes.io/proxy-max-temp-file-size: "0"
+      nginx.ingress.kubernetes.io/client-body-buffer-size: "128k"
+      nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
+      nginx.ingress.kubernetes.io/affinity: "cookie"
+      nginx.ingress.kubernetes.io/affinity-mode: "persistent"
+      nginx.ingress.kubernetes.io/session-cookie-max-age: "1800"
+      nginx.ingress.kubernetes.io/session-cookie-expires: "1800"
+      nginx.ingress.kubernetes.io/session-cookie-name: "xnat-core-dev"
+    hosts:
+      - host: localhost
   config:
     extraWait: 15

--- a/chart/ci/test-values.yaml
+++ b/chart/ci/test-values.yaml
@@ -1,0 +1,20 @@
+---
+replicaCount: 2
+
+image:
+  name: xnat-core
+  tag: latest
+
+imageCredentials:
+  enabled: true
+  registry: ghcr.io
+
+postgresql:
+  cluster:
+    initdb:
+      database: xnatdb
+      owner: xnatuser
+web:
+  siteUrl: http://localhost
+  config:
+    extraWait: 15

--- a/chart/ci/test-values.yaml
+++ b/chart/ci/test-values.yaml
@@ -10,6 +10,7 @@ imageCredentials:
   registry: ghcr.io
 
 postgresql:
+  fullnameOverride: xnat-core-db
   cluster:
     initdb:
       database: xnatdb

--- a/chart/ci/test-values.yaml
+++ b/chart/ci/test-values.yaml
@@ -1,6 +1,8 @@
 ---
 replicaCount: 2
 
+fullnameOverride: xnat-core
+
 image:
   name: xnat-core
   tag: latest
@@ -10,7 +12,7 @@ imageCredentials:
   registry: ghcr.io
 
 postgresql:
-  fullnameOverride: xnat-core-db
+  fullnameOverride: xnat-core
   cluster:
     initdb:
       database: xnatdb

--- a/chart/templates/_postgresql.tpl
+++ b/chart/templates/_postgresql.tpl
@@ -2,5 +2,9 @@
 Name of the postgresql clusterIP service
 */}}
 {{- define "xnat.postgresql.svc" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- printf "%s-rw" .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s-rw" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -95,28 +95,28 @@ volumes:
     existingClaim: false
     persistent: true
     size: 1Gi
-    storageClass: # e.g. local-path for k3s default storage class
+    storageClass:  # e.g. local-path for k3s default storage class
   xnat-cache:
     accessMode: ReadWriteOnce
     annotations: {}
     existingClaim: false
     persistent: true
     size: 10Gi
-    storageClass: # e.g. local-path for k3s default storage class
+    storageClass:  # e.g. local-path for k3s default storage class
   xnat-home-logs:
     accessMode: ReadWriteOnce
     annotations: {}
     existingClaim: false
     persistent: true
     size: 10Gi
-    storageClass: # e.g. local-path for k3s default storage class
+    storageClass:  # e.g. local-path for k3s default storage class
   xnat-home-work:
     accessMode: ReadWriteOnce
     annotations: {}
     existingClaim: false
     persistent: true
     size: 10Gi
-    storageClass: # e.g. local-path for k3s default storage class
+    storageClass:  # e.g. local-path for k3s default storage class
 
 ## @param volumeMounts.xnat-build.mountPath XNAT build volume mount path
 ## @param volumeMounts.xnat-build.subPath XNAT build volume sub path
@@ -173,14 +173,14 @@ extraVolumes:
     existingClaim: false
     persistent: true
     size: 10Gi
-    storageClass: # e.g. local-path for k3s default storage class
+    storageClass:  # e.g. local-path for k3s default storage class
   xnat-prearchive:
     accessMode: ReadWriteOnce
     annotations: {}
     existingClaim: false
     persistent: true
     size: 10Gi
-    storageClass: # e.g. local-path for k3s default storage class
+    storageClass:  # e.g. local-path for k3s default storage class
 
 ## @param extraVolumeMounts.xnat-archive.mountPath XNAT archive volume mount path
 ## @param extraVolumeMounts.xnat-archive.subPath XNAT archive volume sub path

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,17 @@
+# See: https://github.com/helm/chart-testing/blob/main/doc/ct_install.md
+chart-dirs:
+  - .
+chart-repos:
+  - cnpg=https://cloudnative-pg.github.io/charts
+  - nginx=https://kubernetes.github.io/ingress-nginx/
+
+build-id: CI
+
+helm-extra-args: --timeout 600s
+
+validate-maintainers: false
+target-branch: main
+
+namespace: xnat-core
+release-label: app.kubernetes.io/instance
+upgrade: false


### PR DESCRIPTION
- use [`ct`](https://github.com/helm/chart-testing) for testing the Chart
- add a workflow that:
  - spins up a Kind cluster
  - installs the CNPG operator and NGINX controller
  - creates required resources (namespace, secrets)
  - runs `ct lint` to lint the chart
  - runs `ct installl` to install the chart and deploy XNAT
- test vaules are stored in `chart/ci/test-values.yaml`. `ct` will run tests on all `*-values.yaml` files in `chart/ci`
- set the postgresql service name using `postgresql.fullnameOverride` if it is defined to match the behaviour of the CNPG `cluster` chart
- update README